### PR TITLE
feat(CW): Remove no longer needed ACE requirement

### DIFF
--- a/A3-Antistasi/Templates/NewTemplates/CW/CW_AI_CIS.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/CW/CW_AI_CIS.sqf
@@ -227,18 +227,34 @@ _loadoutData setVariable ["items_medical_medic", ["MEDIC"] call A3A_fnc_itemset_
 _loadoutData setVariable ["items_miscEssentials", [] call A3A_fnc_itemset_miscEssentials];
 
 
-_loadoutData setVariable ["items_squadleader_extras", ["ACE_microDAGR", "ACE_DAGR", "Laserbatteries", "Laserbatteries", "Laserbatteries"]];
+if (A3A_hasACE) then {
+	_loadoutData setVariable ["items_squadleader_extras", ["ACE_microDAGR", "ACE_DAGR", "Laserbatteries", "Laserbatteries", "Laserbatteries"]];
+} else {
+	_loadoutData setVariable ["items_squadleader_extras", ["Laserbatteries", "Laserbatteries", "Laserbatteries"]];
+};
 _loadoutData setVariable ["items_rifleman_extras", ["CW_DroidParts"]];
 _loadoutData setVariable ["items_medic_extras", ["CW_DroidParts"]];
 _loadoutData setVariable ["items_grenadier_extras", ["CW_DroidParts"]];
-_loadoutData setVariable ["items_explosivesExpert_extras", ["CW_DroidParts", "Toolkit", "MineDetector", "ACE_Clacker","ACE_DefusalKit"]];
+if (A3A_hasACE) then {
+	_loadoutData setVariable ["items_explosivesExpert_extras", ["CW_DroidParts", "Toolkit", "MineDetector", "ACE_Clacker","ACE_DefusalKit"]];
+} else {
+	_loadoutData setVariable ["items_explosivesExpert_extras", ["CW_DroidParts", "Toolkit", "MineDetector"]];
+};
 _loadoutData setVariable ["items_engineer_extras", ["CW_DroidParts", "Toolkit", "MineDetector"]];
 _loadoutData setVariable ["items_lat_extras", ["CW_DroidParts"]];
 _loadoutData setVariable ["items_at_extras", ["CW_DroidParts"]];
 _loadoutData setVariable ["items_aa_extras", ["CW_DroidParts"]];
 _loadoutData setVariable ["items_machineGunner_extras", ["CW_DroidParts"]];
-_loadoutData setVariable ["items_marksman_extras", ["CW_DroidParts", "ACE_RangeCard", "ACE_ATragMX", "ACE_Kestrel4500"]];
-_loadoutData setVariable ["items_sniper_extras", ["CW_DroidParts", "ACE_RangeCard", "ACE_ATragMX", "ACE_Kestrel4500"]];
+if (A3A_hasACE) then {
+	_loadoutData setVariable ["items_marksman_extras", ["CW_DroidParts", "ACE_RangeCard", "ACE_ATragMX", "ACE_Kestrel4500"]];
+} else {
+	_loadoutData setVariable ["items_marksman_extras", ["CW_DroidParts"]];
+};
+if (A3A_hasACE) then {
+	_loadoutData setVariable ["items_sniper_extras", ["CW_DroidParts", "ACE_RangeCard", "ACE_ATragMX", "ACE_Kestrel4500"]];
+} else {
+	_loadoutData setVariable ["items_sniper_extras", ["CW_DroidParts"]];
+};
 _loadoutData setVariable ["items_police_extras", ["CW_DroidParts"]];
 _loadoutData setVariable ["items_crew_extras", ["CW_DroidParts"]];
 _loadoutData setVariable ["items_unarmed_extras", ["CW_DroidParts"]];

--- a/A3-Antistasi/Templates/NewTemplates/CW/CW_AI_CISHol.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/CW/CW_AI_CISHol.sqf
@@ -227,18 +227,34 @@ _loadoutData setVariable ["items_medical_medic", ["MEDIC"] call A3A_fnc_itemset_
 _loadoutData setVariable ["items_miscEssentials", [] call A3A_fnc_itemset_miscEssentials];
 
 
-_loadoutData setVariable ["items_squadleader_extras", ["ACE_microDAGR", "ACE_DAGR", "Laserbatteries", "Laserbatteries", "Laserbatteries"]];
+if (A3A_hasACE) then {
+	_loadoutData setVariable ["items_squadleader_extras", ["ACE_microDAGR", "ACE_DAGR", "Laserbatteries", "Laserbatteries", "Laserbatteries"]];
+} else {
+	_loadoutData setVariable ["items_squadleader_extras", ["Laserbatteries", "Laserbatteries", "Laserbatteries"]];
+};
 _loadoutData setVariable ["items_rifleman_extras", ["CW_DroidParts"]];
 _loadoutData setVariable ["items_medic_extras", ["CW_DroidParts"]];
 _loadoutData setVariable ["items_grenadier_extras", ["CW_DroidParts"]];
-_loadoutData setVariable ["items_explosivesExpert_extras", ["CW_DroidParts", "Toolkit", "MineDetector", "ACE_Clacker","ACE_DefusalKit"]];
+if (A3A_hasACE) then {
+	_loadoutData setVariable ["items_explosivesExpert_extras", ["CW_DroidParts", "Toolkit", "MineDetector", "ACE_Clacker","ACE_DefusalKit"]];
+} else {
+	_loadoutData setVariable ["items_explosivesExpert_extras", ["CW_DroidParts", "Toolkit", "MineDetector"]];
+};
 _loadoutData setVariable ["items_engineer_extras", ["CW_DroidParts", "Toolkit", "MineDetector"]];
 _loadoutData setVariable ["items_lat_extras", ["CW_DroidParts"]];
 _loadoutData setVariable ["items_at_extras", ["CW_DroidParts"]];
 _loadoutData setVariable ["items_aa_extras", ["CW_DroidParts"]];
 _loadoutData setVariable ["items_machineGunner_extras", ["CW_DroidParts"]];
-_loadoutData setVariable ["items_marksman_extras", ["CW_DroidParts", "ACE_RangeCard", "ACE_ATragMX", "ACE_Kestrel4500"]];
-_loadoutData setVariable ["items_sniper_extras", ["CW_DroidParts", "ACE_RangeCard", "ACE_ATragMX", "ACE_Kestrel4500"]];
+if (A3A_hasACE) then {
+	_loadoutData setVariable ["items_marksman_extras", ["CW_DroidParts", "ACE_RangeCard", "ACE_ATragMX", "ACE_Kestrel4500"]];
+} else {
+	_loadoutData setVariable ["items_marksman_extras", ["CW_DroidParts"]];
+};
+if (A3A_hasACE) then {
+	_loadoutData setVariable ["items_sniper_extras", ["CW_DroidParts", "ACE_RangeCard", "ACE_ATragMX", "ACE_Kestrel4500"]];
+} else {
+	_loadoutData setVariable ["items_sniper_extras", ["CW_DroidParts"]];
+};
 _loadoutData setVariable ["items_police_extras", ["CW_DroidParts"]];
 _loadoutData setVariable ["items_crew_extras", ["CW_DroidParts"]];
 _loadoutData setVariable ["items_unarmed_extras", ["CW_DroidParts"]];

--- a/A3-Antistasi/Templates/NewTemplates/CW/CW_AI_IMP.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/CW/CW_AI_IMP.sqf
@@ -229,18 +229,34 @@ _loadoutData setVariable ["items_medical_medic", ["MEDIC"] call A3A_fnc_itemset_
 _loadoutData setVariable ["items_miscEssentials", [] call A3A_fnc_itemset_miscEssentials];
 
 
-_loadoutData setVariable ["items_squadleader_extras", ["ACE_microDAGR", "ACE_DAGR", "Laserbatteries", "Laserbatteries", "Laserbatteries"]];
+if (A3A_hasACE) then {
+	_loadoutData setVariable ["items_squadleader_extras", ["ACE_microDAGR", "ACE_DAGR", "Laserbatteries", "Laserbatteries", "Laserbatteries"]];
+} else {
+	_loadoutData setVariable ["items_squadleader_extras", ["Laserbatteries", "Laserbatteries", "Laserbatteries"]];
+};
 _loadoutData setVariable ["items_rifleman_extras", []];
 _loadoutData setVariable ["items_medic_extras", []];
 _loadoutData setVariable ["items_grenadier_extras", []];
-_loadoutData setVariable ["items_explosivesExpert_extras", ["Toolkit", "MineDetector", "ACE_Clacker","ACE_DefusalKit"]];
+if (A3A_hasACE) then {
+	_loadoutData setVariable ["items_explosivesExpert_extras", ["Toolkit", "MineDetector", "ACE_Clacker","ACE_DefusalKit"]];
+} else {
+	_loadoutData setVariable ["items_explosivesExpert_extras", ["Toolkit", "MineDetector"]];
+};
 _loadoutData setVariable ["items_engineer_extras", ["Toolkit", "MineDetector"]];
 _loadoutData setVariable ["items_lat_extras", []];
 _loadoutData setVariable ["items_at_extras", []];
 _loadoutData setVariable ["items_aa_extras", []];
 _loadoutData setVariable ["items_machineGunner_extras", []];
-_loadoutData setVariable ["items_marksman_extras", ["ACE_RangeCard", "ACE_ATragMX", "ACE_Kestrel4500"]];
-_loadoutData setVariable ["items_sniper_extras", ["ACE_RangeCard", "ACE_ATragMX", "ACE_Kestrel4500"]];
+if (A3A_hasACE) then {
+	_loadoutData setVariable ["items_marksman_extras", ["ACE_RangeCard", "ACE_ATragMX", "ACE_Kestrel4500"]];
+} else {
+	_loadoutData setVariable ["items_marksman_extras", []];
+};
+if (A3A_hasACE) then {
+	_loadoutData setVariable ["items_sniper_extras", ["ACE_RangeCard", "ACE_ATragMX", "ACE_Kestrel4500"]];
+} else {
+	_loadoutData setVariable ["items_sniper_extras", []];
+};
 _loadoutData setVariable ["items_police_extras", []];
 _loadoutData setVariable ["items_crew_extras", []];
 _loadoutData setVariable ["items_unarmed_extras", []];

--- a/A3-Antistasi/Templates/NewTemplates/CW/CW_AI_REP.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/CW/CW_AI_REP.sqf
@@ -229,18 +229,34 @@ _loadoutData setVariable ["items_medical_medic", ["MEDIC"] call A3A_fnc_itemset_
 _loadoutData setVariable ["items_miscEssentials", [] call A3A_fnc_itemset_miscEssentials];
 
 
-_loadoutData setVariable ["items_squadleader_extras", ["ACE_microDAGR", "ACE_DAGR", "Laserbatteries", "Laserbatteries", "Laserbatteries"]];
+if (A3A_hasACE) then {
+	_loadoutData setVariable ["items_squadleader_extras", ["ACE_microDAGR", "ACE_DAGR", "Laserbatteries", "Laserbatteries", "Laserbatteries"]];
+} else {
+	_loadoutData setVariable ["items_squadleader_extras", ["Laserbatteries", "Laserbatteries", "Laserbatteries"]];
+};
 _loadoutData setVariable ["items_rifleman_extras", []];
 _loadoutData setVariable ["items_medic_extras", []];
 _loadoutData setVariable ["items_grenadier_extras", []];
-_loadoutData setVariable ["items_explosivesExpert_extras", ["Toolkit", "MineDetector", "ACE_Clacker","ACE_DefusalKit"]];
+if (A3A_hasACE) then {
+	_loadoutData setVariable ["items_explosivesExpert_extras", ["Toolkit", "MineDetector", "ACE_Clacker","ACE_DefusalKit"]];
+} else {
+	_loadoutData setVariable ["items_explosivesExpert_extras", ["Toolkit", "MineDetector"]];
+};
 _loadoutData setVariable ["items_engineer_extras", ["Toolkit", "MineDetector"]];
 _loadoutData setVariable ["items_lat_extras", []];
 _loadoutData setVariable ["items_at_extras", []];
 _loadoutData setVariable ["items_aa_extras", []];
 _loadoutData setVariable ["items_machineGunner_extras", []];
-_loadoutData setVariable ["items_marksman_extras", ["ACE_RangeCard", "ACE_ATragMX", "ACE_Kestrel4500"]];
-_loadoutData setVariable ["items_sniper_extras", ["ACE_RangeCard", "ACE_ATragMX", "ACE_Kestrel4500"]];
+if (A3A_hasACE) then {
+	_loadoutData setVariable ["items_marksman_extras", ["ACE_RangeCard", "ACE_ATragMX", "ACE_Kestrel4500"]];
+} else {
+	_loadoutData setVariable ["items_marksman_extras", []];
+};
+if (A3A_hasACE) then {
+	_loadoutData setVariable ["items_sniper_extras", ["ACE_RangeCard", "ACE_ATragMX", "ACE_Kestrel4500"]];
+} else {
+	_loadoutData setVariable ["items_sniper_extras", []];
+};
 _loadoutData setVariable ["items_police_extras", []];
 _loadoutData setVariable ["items_crew_extras", []];
 _loadoutData setVariable ["items_unarmed_extras", []];

--- a/A3-Antistasi/Templates/detector.sqf
+++ b/A3-Antistasi/Templates/detector.sqf
@@ -275,13 +275,6 @@ if (A3A_hasAceMedical && isClass (configFile >> "CfgPatches" >> "LIB_core")) the
 	["modUnautorized",false,1,false,false] call BIS_fnc_endMission;
 };
 
-if (!A3A_hasAceMedical && A3A_hasCW) then {
-	private _text = "Clone Wars modset loaded but Ace is missing, please load Ace";
-  systemChat _text;
-  [1, _text, _fileName] call A3A_fnc_log;
-	["modUnautorized",false,1,false,false] call BIS_fnc_endMission;
-};
-
 if (!A3A_hasCup && A3A_hasSwe) then {
 	private _text = "Swedish Forces Pack detected but CUP is not loaded";
   systemChat _text;


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Information: Kobra does not require ACE, but is compatible with it. @stutpip123 's older CW Antistasi map already had this fixed, and it made sense that it should be doable here. I tested it on a dedicated and hosted and it worked fine -- there were some errors with the loadout scripts, but I got those errors without these changes, as well. There's probably a number of other issues within the CW modpacks, but it seems stable enough to play.

### Please specify which Issue this PR Resolves.
n/a 

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: Start up without ACE and with ACE, both will function and get different loadouts, depending.

********************************************************
Notes: I'm really not sure what's up with the loadout errors I see when launching a LAN / EDEN host? they don't show up in the report outputs / logs, and they disappear on startup before I can read them when starting the host.